### PR TITLE
Make it clear that the installer will overwrite the disk

### DIFF
--- a/6_generate_rootfs.sh
+++ b/6_generate_rootfs.sh
@@ -126,7 +126,7 @@ ls -1 /dev/sd*
 echo "Which device would you like to install Redox to?"
 read device
 
-echo "Are you sure you want to install Redox to $device (y/n)?"
+echo "Are you sure you want to install Redox to $device ? All the data on this disk will be lost. (y/n)"
 read prompt
 if [ "$prompt" == "y" ]
 then


### PR DESCRIPTION
Currently, the installer does not warn the user that it will overwrite the *whole* disk, which could lead to serious data loss.